### PR TITLE
Fix name state bug

### DIFF
--- a/src/states/reducers/nameReducer.ts
+++ b/src/states/reducers/nameReducer.ts
@@ -1,23 +1,37 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-const initialState = {
+// Define the shape of this slice of state so TypeScript can help us catch bugs
+interface NameState {
+  name: string;
+  user: {
+    firstname: string;
+    middlename: string;
+    lastname: string;
+    username: string;
+    level: string;
+  };
+}
+
+const initialState: NameState = {
+  name: "Wayne",
   user: {
     firstname: "Wayne",
     middlename: "Wayne",
     lastname: "Wayne",
     username: "Wayne",
-    level: "Guest"
-  }
+    level: "Guest",
+  },
 };
 
 const nameSlice = createSlice({
   name: "name",
   initialState: initialState,
   reducers: {
-    setName: (state, action) => {
+    setName: (state, action: PayloadAction<string>) => {
+      // Update the name value in the store
       state.name = action.payload;
-    }
-  }
+    },
+  },
 });
 
 export const nameActions = nameSlice.actions;


### PR DESCRIPTION
## Summary
- fix missing `name` field in `nameReducer`
- add type annotations for the name slice

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684037f4d8d8832693bfcca2a40e8945