### PR TITLE
Improve Redux hooks and components

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint -c .eslintrc.cjs . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import Heading from "./components/Heading";
-import { Provider } from "react-redux";
-import store from "./states/store";
-import TextField from "./components/TextField";
+import React from 'react';
+import Heading from './components/Heading';
+import { Provider } from 'react-redux';
+import store from './states/store';
+import TextField from './components/TextField';
 
-function App() {
+const App: React.FC = () => {
   return (
     <Provider store={store}>
       <Heading />
@@ -13,7 +13,7 @@ function App() {
 
       <TextField />
     </Provider>
-  )
-}
+  );
+};
 
-export default App
+export default App;

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -1,13 +1,10 @@
-import React from "react";
-import { useSelector } from "react-redux";
-import { RootState } from "../states/store";
+import React from 'react';
+import { useAppSelector } from '../states/hooks';
 
-const Heading: React.FunctionComponent = () => {
-  const name = useSelector((state: RootState) => state.nameReducer.name);
+const Heading: React.FC = React.memo(() => {
+  const name = useAppSelector((state) => state.nameReducer.name);
 
-  return (
-    <h1>{name}</h1>
-  );
-};
+  return <h1>{name}</h1>;
+});
 
 export default Heading;

--- a/src/components/ProtectedComponent.tsx
+++ b/src/components/ProtectedComponent.tsx
@@ -1,25 +1,24 @@
-import { useSelector } from "react-redux";
-import { RootState } from "../states/store";
+import React from 'react';
+import { useAppSelector } from '../states/hooks';
 
-const ProtectedComponent = () => {
-  const level = useSelector((state: RootState) => state.nameReducer.user.level);
+const AdminPage = () => <h2>Admin</h2>;
+const ModeratorPage = () => <h2>Moderator</h2>;
+const GuestPage = () => <h2>Guest</h2>;
+
+const ProtectedComponent: React.FC = () => {
+  const level = useAppSelector((state) => state.nameReducer.user.level);
 
   return (
     <>
-      {
-        level == "Admin" ?
-          <AdminPage />
-          :
-          level == "Moderator" ?
-            <ModeratorPage/>
-            :
-            level == "Guest" ?
-            <GuestPage/>
-            :
-            <React.Fragment />
-      }
+      {level === 'Admin' ? (
+        <AdminPage />
+      ) : level === 'Moderator' ? (
+        <ModeratorPage />
+      ) : level === 'Guest' ? (
+        <GuestPage />
+      ) : null}
     </>
   );
-}
+};
 
 export default ProtectedComponent;

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -1,13 +1,15 @@
-import React from "react";
-import { useDispatch } from "react-redux";
-import { nameActions } from "../states/reducers/nameReducer";
+import React from 'react';
+import { useAppDispatch } from '../states/hooks';
+import { nameActions } from '../states/reducers/nameReducer';
 
-const TextField: React.FunctionComponent = () => {
-  const dispatch = useDispatch();
+const TextField: React.FC = () => {
+  const dispatch = useAppDispatch();
 
-  return (
-    <input type="text" onChange={(event) => dispatch(nameActions.setName(event.target.value))}/>
-  );
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(nameActions.setName(event.target.value));
+  };
+
+  return <input type="text" onChange={handleChange} />;
 };
 
 export default TextField;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-)
+);

--- a/src/states/hooks.ts
+++ b/src/states/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/states/store.ts
+++ b/src/states/store.ts
@@ -1,10 +1,10 @@
-import { configureStore } from "@reduxjs/toolkit";
-import nameReducer from "./reducers/nameReducer";
+import { configureStore } from '@reduxjs/toolkit';
+import nameReducer from './reducers/nameReducer';
 
 const store = configureStore({
-  reducer: { nameReducer }
+  reducer: { nameReducer },
 });
 
-export type RootState = ReturnType<typeof store.getState>
-export type AppDispatch = typeof store.dispatch
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
 export default store;


### PR DESCRIPTION
## Summary
- use typed Redux hooks for better type inference
- memoize `Heading` component
- add placeholders to `ProtectedComponent`
- refine `TextField` input handling
- convert components to `React.FC`
- update main entry
- fix lint script for ESLint 9

## Testing
- `npm run lint` *(fails: config object uses unsupported key)*
- `ESLINT_USE_FLAT_CONFIG=false npm run lint` *(fails: plugin not found)*
- `npm run build` *(fails: cannot find module 'react')*


------
https://chatgpt.com/codex/tasks/task_e_6841347c86e883268774ccb9f3994c82